### PR TITLE
Hotfix

### DIFF
--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -97,6 +97,8 @@ def get_scoreboard(contest):
                 new_submission = ScoreboardSubmission(submission.submit_time,passed_testcases)
                 new_problem.add_submission(new_submission)
                 if new_submission.is_solved(total_testcases):
+                    new_problem.AC_time = new_submission.submit_time - contest.start_time
+                    new_problem.AC_time = int(new_problem.AC_time.total_seconds()/60)
                     break
             if new_problem.is_solved():
                 scoreboard.get_problem(new_problem.id).add_pass_user()

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -189,7 +189,7 @@ def write_scoreboard_csv_testcases(writer, contest, scoreboard):
 
 def get_clarifications(user, contest):
 
-    if has_contest_ownership(user,contest):
+    if has_contest_ownership(user,contest) or user.has_admin_auth():
         return Clarification.objects.filter(contest = contest)
     reply_all = Clarification.objects.filter(contest = contest, reply_all = True)
     if user.is_authenticated():

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -151,8 +151,8 @@ def write_scoreboard_csv_penalty(writer, contest, scoreboard):
         user_row = [counter+1, user.username]
         for problem in user.problems:
             submit_times = problem.submit_times
-            penalty = get_penalty(problem, contest.start_time)
-            user_row.append(str(submit_times) + '/' + str(penalty))
+            AC_time = problem.AC_time
+            user_row.append(str(submit_times) + '/' + str(AC_time))
         total_penalty = user.get_penalty(contest.start_time)
         user_row.append(total_penalty)
         writer.writerow(user_row)

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -217,6 +217,14 @@ def is_contestant(user, contest):
     contestant = Contestant.objects.filter(contest = contest, user = user)
     return (len(contestant)>=1)
 
+def is_coowner(user, contest):
+    user = validate_user(user)
+    coowners = contest.coowner.all()
+    for coowner in coowners:
+        if user == coowner:
+            return True
+    return False
+
 #check if user can create new clarification in contest
 '''
 admin and owner and coowner and contestant can create clarification

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -84,6 +84,7 @@ def get_scoreboard(contest):
     for problem in contest.problem.all():
         total_testcases = get_total_testcases(problem);
         new_problem = ScoreboardProblem(problem.id,problem.pname,total_testcases)
+        new_problem.no_submission = True
         scoreboard.add_problem(new_problem)
 
     for contestant in contestants:
@@ -104,6 +105,9 @@ def get_scoreboard(contest):
                 scoreboard.get_problem(new_problem.id).add_pass_user()
             else:
                 new_problem.AC_time = '--'
+            if len(submissions):
+                scoreboard.get_problem(new_problem.id).no_submission = False
+
             #setup problem attribute
             new_problem.penalty = get_penalty(new_problem,scoreboard.start_time)
             new_problem.submit_times = get_submit_times(new_problem)

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -102,6 +102,8 @@ def get_scoreboard(contest):
                     break
             if new_problem.is_solved():
                 scoreboard.get_problem(new_problem.id).add_pass_user()
+            else:
+                new_problem.AC_time = '--'
             #setup problem attribute
             new_problem.penalty = get_penalty(new_problem,scoreboard.start_time)
             new_problem.submit_times = get_submit_times(new_problem)

--- a/contest/forms.py
+++ b/contest/forms.py
@@ -39,9 +39,10 @@ class ContestForm(forms.ModelForm):
         # access object through self.instance...
         initial = kwargs.get('initial',{})
         user = initial.get('user',User())
+        owner = initial.get('owner',User())
         method = initial.get('method','')
         self.fields['coowner'].queryset = User.objects.exclude(
-            Q(user_level=User.USER)|Q(pk = user.pk))
+            Q(user_level=User.USER)|Q(pk = owner))
         if method == 'GET':
             contest_id = initial.get('id',0)
             # if user not is admin

--- a/contest/static/contest/css/contest.css
+++ b/contest/static/contest/css/contest.css
@@ -22,8 +22,13 @@ SOFTWARE.
   color: green;
 }
 
+td.word-block {
+	word-wrap:break-word;
+}
+
+/*
 div.inline>ul>li {
   position: absolute;
   display: inline;
-}
+}*/
 

--- a/contest/static/contest/css/contest.css
+++ b/contest/static/contest/css/contest.css
@@ -18,7 +18,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+.green {
+  color: green;
+}
+
 div.inline>ul>li {
   position: absolute;
   display: inline;
 }
+

--- a/contest/static/contest/css/contestArchive.css
+++ b/contest/static/contest/css/contestArchive.css
@@ -18,10 +18,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-a.black {
-  color: black;
-}
-
 td.not-clickable-area {
 	background-color: #A0A0A0;
 	text-align:center;

--- a/contest/static/contest/js/contest.js
+++ b/contest/static/contest/js/contest.js
@@ -27,9 +27,11 @@ function init(){
     tabInit();
 }
 
-function select(target, description, reply){
+function select(target){
     document.getElementById("id_clarification").value = target;
-    $('#description').html(description);
+    var content = $('#content'+target).html();
+    var reply = $('#reply'+target).html();
+    $('#description').html(content);
     $('#id_reply').val(reply);
 }
 

--- a/contest/static/contest/js/contest.js
+++ b/contest/static/contest/js/contest.js
@@ -27,9 +27,10 @@ function init(){
     tabInit();
 }
 
-function select(target, description){
+function select(target, description, reply){
     document.getElementById("id_clarification").value = target;
     $('#description').html(description);
+    $('#id_reply').val(reply);
 }
 
 function tabInit(){

--- a/contest/static/contest/js/contest.js
+++ b/contest/static/contest/js/contest.js
@@ -35,6 +35,10 @@ function select(target){
     $('#id_reply').val(reply);
 }
 
+function noResponse(){
+    $('#id_reply').val("No Response. Please read the problem statement");
+}
+
 function tabInit(){
     //initialize
     $('#contest_tab a').click(function(e) {

--- a/contest/static/contest/js/editContest.js
+++ b/contest/static/contest/js/editContest.js
@@ -23,6 +23,7 @@ $(document).ready(function() {
     hide('id_owner');
     enable_search();
     modify_label();
+    widen_multiselect();
 });
 
 function enable_search() {
@@ -65,6 +66,11 @@ function enable_search() {
             this.qs2.cache();
         }
     });
+}
+
+function widen_multiselect(){
+    add_attribute('ms-id_coowner','style','width:100%;');
+    add_attribute('ms-id_problem','style','width:100%;');
 }
 
 function modify_label(){

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -74,7 +74,9 @@
               <td>
               <button name="reply" type="button" class="btn btn-warning btn-xs"
                       data-toggle="modal" data-target="#reply"
-                      onclick="select({{ clarification.id }},'{{ clarification.content }}')">Reply</button>
+                      onclick="select({{ clarification.id }},'{{ clarification.content }}',
+                      '{{ clarification.reply }}')">
+                      Reply</button>
               </td>
               {% endif %}
               <td>{{ forloop.counter }}</td>

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -65,6 +65,7 @@
               <th>Reply</th>
               <th>Replier</th>
               <th>Reply Time</th>
+              <th>For all team</th>
             </tr>
           </thead>
           <tbody>
@@ -83,7 +84,12 @@
               <td id="content{{ clarification.id }}">{{ clarification.content }}</td>
               <td id="reply{{ clarification.id }}">{{ clarification.reply }}</td>
               <td>{{ clarification.replier }}</td>
-              <td>{{ clarification.reply_time }}</td>
+              <td>{{ clarification.reply_time|date:"Y/m/d H:i:s" }}</td>
+              <td>
+              {% if clarification.reply_all%}
+              <span class="glyphicon glyphicon-ok green" aria-hidden="true"></span>
+              {% endif %}
+              </td>
             </tr>
             {% endfor %}
           </tbody>

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -52,20 +52,20 @@
         <h1 class="panel-title" style="text-align:center;">Clarification</h1>
       </div>
       <div id="contest_clarification">
-        <table class="table">
+        <table class="table" style="table-layout: fixed; width: 100%">
           <thead>
             <tr>
               {% if user|can_reply:contest %}
-                <th></th>
+                <th width="5%"></th>
               {% endif %}
-              <th>#</th>
-              <th>Problem</th>
-              <th>Asker</th>
-              <th>Description</th>
-              <th>Reply</th>
-              <th>Replier</th>
-              <th>Reply Time</th>
-              <th>For all team</th>
+              <th width="2%">#</th>
+              <th width="15%">Problem</th>
+              <th width="10%">Asker</th>
+              <th width="20%">Description</th>
+              <th width="20%">Reply</th>
+              <th width="10%">Replier</th>
+              <th width="10%">Reply Time</th>
+              <th width="5%">For all team</th>
             </tr>
           </thead>
           <tbody>
@@ -81,8 +81,8 @@
               <td>{{ forloop.counter }}</td>
               <td>{{ clarification.problem }}</td>
               <td>{{ clarification.asker }}</td>
-              <td id="content{{ clarification.id }}">{{ clarification.content }}</td>
-              <td id="reply{{ clarification.id }}">{{ clarification.reply }}</td>
+              <td class="word-block" id="content{{ clarification.id }}">{{ clarification.content }}</td>
+              <td class="word-block" id="reply{{ clarification.id }}">{{ clarification.reply }}</td>
               <td>{{ clarification.replier }}</td>
               <td>{{ clarification.reply_time|date:"Y/m/d H:i:s" }}</td>
               <td>

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -74,16 +74,14 @@
               <td>
               <button name="reply" type="button" class="btn btn-warning btn-xs"
                       data-toggle="modal" data-target="#reply"
-                      onclick="select({{ clarification.id }},'{{ clarification.content }}',
-                      '{{ clarification.reply }}')">
-                      Reply</button>
+                      onclick="select({{ clarification.id }})">Reply</button>
               </td>
               {% endif %}
               <td>{{ forloop.counter }}</td>
               <td>{{ clarification.problem }}</td>
               <td>{{ clarification.asker }}</td>
-              <td>{{ clarification.content }}</td>
-              <td>{{ clarification.reply }}</td>
+              <td id="content{{ clarification.id }}">{{ clarification.content }}</td>
+              <td id="reply{{ clarification.id }}">{{ clarification.reply }}</td>
               <td>{{ clarification.replier }}</td>
               <td>{{ clarification.reply_time }}</td>
             </tr>

--- a/contest/templates/contest/contestArchive.html
+++ b/contest/templates/contest/contestArchive.html
@@ -79,7 +79,7 @@
           {% endif %}
         </td>
         <td>{{ contest.id }}</td>
-        <td><a class="black" href="{% url 'contest:contest' contest.id %}">{{ contest.cname }}</a>
+        <td><a href="{% url 'contest:contest' contest.id %}">{{ contest.cname }}</a>
         </td>
         <td>{{ contest.start_time|date:"Y/m/d H:i:s" }}</td>
         <td>{{ contest.end_time|date:"Y/m/d H:i:s" }}</td>

--- a/contest/templates/contest/contestInfo.html
+++ b/contest/templates/contest/contestInfo.html
@@ -26,7 +26,9 @@
           <thead>
             <tr>
               {% if user|has_auth:contest.id %}
+              <!--
               <th style="text-align:center;width:20%;">Rejudge</th>
+              -->
               {% endif %}
               <th style="text-align:center;width:20%;">#</th>
               <th style="text-align:center;width:60%;">Problem</th>
@@ -36,11 +38,13 @@
             {% for problem in contest.problem.all %}
             <tr>
               {% if user|has_auth:contest.id %}
+              <!--
               <td>
                 <button type="button" class="btn btn-warning btn-xs">
                   <span class="glyphicon glyphicon-refresh"></span>
                 </button>
               </td>
+              -->
               {% endif %}
               <td>{{ forloop.counter }}</td>
               <td>{{ problem }}</td>
@@ -54,7 +58,9 @@
           <thead>
             <tr>
               {% if user|has_auth:contest.id %}
+              <!--
               <th style="width:20%;"></th>
+              -->
               {% endif %}
               <th style="text-align:center;width:20%;">#</th>
               <th style="text-align:center;width:60%;">Contestant</th>
@@ -64,11 +70,13 @@
             {% for contestant in contest.contestants %}
             <tr>
               {% if user|has_auth:contest.id %}
+              <!--
               <td>
                 <button type="button" class="btn btn-danger btn-xs">
                   <span class="glyphicon glyphicon-minus"></span>
                 </button>
               </td>
+            -->
               {% endif %}
               <td>{{ forloop.counter }}</td>
               <td>{{ contestant }}</td>

--- a/contest/templates/contest/editContest.html
+++ b/contest/templates/contest/editContest.html
@@ -1,5 +1,6 @@
 {% extends "index/base.html" %} 
 {% load staticfiles %}
+{% load contest_extras %}
 {% block title_name %}
 {% load bootstrap %}
 <title>{{ title }}</title>
@@ -16,8 +17,8 @@
   <div class="well">
     <h2>
     {{ title }}
-    {% if cid %}
-    <a href="{% url 'contest:contest' cid %}">
+    {% if contest %}
+    <a href="{% url 'contest:contest' contest.id %}">
       <button type="button" class="btn btn-primary">
         See this contest
       </button>
@@ -34,7 +35,13 @@
     {% csrf_token %}
     {% for field in form %}
     {% if field.label_tag == form.owner.label_tag %}
-    	{{ field.as_hidden }}
+      {{ field.as_hidden }}
+    {% elif field.label_tag == form.coowner.label_tag %}
+      {% if user|is_coowner:contest %}
+      {{ field.as_hidden }}
+      {% else %}
+      {{ field|bootstrap }}
+      {% endif %}
     {% else %}
       {{ field|bootstrap }}
     {% endif %}

--- a/contest/templates/contest/reply.html
+++ b/contest/templates/contest/reply.html
@@ -24,6 +24,7 @@
             <label>{{ reply_form.reply_all }}Reply  All</label>
           </div>
           <div class="modal-footer">
+            <button type="button" class="btn btn-warning" onclick="noResponse()">No Response</button>
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
             <input type="submit" class="btn btn-primary" value="Send">
           </div>

--- a/contest/templates/contest/reply.html
+++ b/contest/templates/contest/reply.html
@@ -21,7 +21,7 @@
             {{ reply_form.reply }}
           </div>
           <div class="checkbox">
-            <label>{{ reply_form.reply_all }}Reply All</label>
+            <label>{{ reply_form.reply_all }}Reply  All</label>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/contest/templates/contest/scoreboard.html
+++ b/contest/templates/contest/scoreboard.html
@@ -100,7 +100,7 @@
             <td>{{ forloop.counter }}</td>
             <td>{{ user.username }}</td>
             {% for problem in user.problems %}
-            <td>{{ problem.submit_times }}/{{ problem.penalty }}</td>
+            <td>{{ problem.submit_times }}/{{ problem.AC_time }}</td>
             {% endfor %}
             <td>{{ user.solved }}</td>
             <td>{{ user.penalty }}</td>

--- a/contest/templatetags/contest_extras.py
+++ b/contest/templatetags/contest_extras.py
@@ -69,11 +69,11 @@ def can_reply(user, contest):
     return contest_info.can_reply(user,contest)
 register.filter("can_reply", can_reply)
 
-#check if user is anonymous user
+#check if user is coowner
 @register.filter
-def is_anonymous(user):
-    return user_info.is_anonymous(user)
-register.filter("is_anonymous", is_anonymous)
+def is_coowner(user, contest):
+    return contest_info.is_coowner(user, contest)
+register.filter("is_coowner", is_coowner)
 
 #check if user is judge or admin
 @register.filter

--- a/contest/views.py
+++ b/contest/views.py
@@ -88,7 +88,7 @@ def register_page(request, cid):
 
 #contest datail page
 def contest(request, cid):
-    user = request.user
+    user = user_info.validate_user(request.user)
     try:
         contest = Contest.objects.get(id = cid)
     except Contest.DoesNotExist:
@@ -97,8 +97,8 @@ def contest(request, cid):
 
     now = datetime.now()
     #if contest has not started and user is not the owner
-    if ((contest.start_time < now) or user_info.has_contest_ownership(request.user,contest) or\
-        request.user.has_admin_auth()):
+    if ((contest.start_time < now) or user_info.has_contest_ownership(user,contest) or\
+        user.has_admin_auth()):
         for problem in contest.problem.all():
             problem.testcase = get_testcase(problem)
         scoreboard = get_scoreboard(contest)
@@ -233,6 +233,8 @@ def ask(request):
             form = ClarificationForm(request.POST)
             if form.is_valid():
                 new_clarification = form.save()
+                new_clarification.reply = ''
+                new_clarification.save()
                 logger.info('Clarification: User %s create Clarification %s!'
                     % (request.user.username, new_clarification.id))
             return redirect('contest:contest',contest)

--- a/contest/views.py
+++ b/contest/views.py
@@ -224,9 +224,9 @@ def ask(request):
         contest = request.POST['contest']
         contest_obj = Contest.objects.get(pk = contest)
     except:
-        logger.warning('Clarification: Can not create Clarification! Contest %s not found!'
-            % contest)
-        return redirect('contest:archive')
+        logger.warning('Clarification: User %s can not create Clarification!' % 
+            request.user.username)
+        raise Http404('Contest does not exist, can not ask.')
 
     if can_ask(request.user,contest_obj):
         if request.method == 'POST':
@@ -248,9 +248,9 @@ def reply(request):
         contest_obj = instance.contest
         contest = contest_obj.id
     except:
-        logger.warning('Clarification: User %s can not reply Clarification %s!'
-            % (request.user.username, clarification))
-        return redirect('contest:archive')
+        logger.warning('Clarification: User %s can not reply Clarification!'
+            % (request.user.username))
+        raise Http404('Contest does not exist, can not reply.')
 
     if can_reply(request.user,contest_obj):
         if request.method == 'POST':

--- a/contest/views.py
+++ b/contest/views.py
@@ -166,7 +166,7 @@ def edit(request, cid):
             form = ContestForm(initial = contest_dic)
 
             return render_index(request,'contest/editContest.html',
-                    {'form':form, 'title':title, 'cid':contest.id})
+                    {'form':form, 'title':title, 'contest':contest})
 
         if request.method == 'POST':
             form = ContestForm(request.POST, instance = contest, 
@@ -185,7 +185,7 @@ def edit(request, cid):
                 message = 'Some fields are invalid!'
                 messages.error(request, message)
                 return render_index(request,'contest/editContest.html',
-                    {'form':form,'title':title, 'cid':contest.id})
+                    {'form':form,'title':title, 'contest':contest})
 
     raise PermissionDenied
 

--- a/contest/views.py
+++ b/contest/views.py
@@ -249,17 +249,20 @@ def reply(request):
         contest = contest_obj.id
     except:
         logger.warning('Clarification: User %s can not reply Clarification %s!'
-            % (request.user.username, clarification.id))
+            % (request.user.username, clarification))
         return redirect('contest:archive')
 
     if can_reply(request.user,contest_obj):
         if request.method == 'POST':
-            form = ReplyForm(request.POST or None, instance = instance)
+            form = ReplyForm(request.POST, instance = instance)
             if form.is_valid():
                 replied_clarification = form.save()
                 replied_clarification.reply_time = datetime.now()
                 replied_clarification.save()
                 logger.info('Clarification: User %s reply Clarification %s!'
+                    % (request.user.username, replied_clarification.id))
+            else:
+                logger.warning('Clarification: User %s can not reply Clarification %s!'
                     % (request.user.username, replied_clarification.id))
             return redirect('contest:contest',contest)
     return redirect('contest:archive')

--- a/contest/views.py
+++ b/contest/views.py
@@ -281,7 +281,7 @@ def ask(request):
             form = ClarificationForm(request.POST)
             if form.is_valid():
                 new_clarification = form.save()
-                new_clarification.reply = ''
+                new_clarification.reply = ' '
                 new_clarification.save()
                 logger.info('Clarification: User %s create Clarification %s!'
                     % (request.user.username, new_clarification.id))

--- a/status/views.py
+++ b/status/views.py
@@ -31,6 +31,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.serializers import serialize
 
 from contest.models import Contest
+from contest.models import Contestant
 from problem.models import Submission, SubmissionDetail, Problem
 from status.templatetags.status_filters import show_detail, submission_filter
 from users.forms import CodeSubmitForm
@@ -108,8 +109,13 @@ def status(request):
 def contest_status(request, contest):
     """Return a status table of given contest"""
     problems = contest.problem.all()
+    contestants = Contestant.objects.filter(contest = contest)
+    users = []
+    for contestant in contestants:
+        users.append(contestant.user)
     submissions = Submission.objects.filter(
         problem__in=problems,
+        user__in=users,
         submit_time__gte=contest.start_time,
         submit_time__lte=contest.end_time).order_by('-id')[0:25]
 


### PR DESCRIPTION
1. clarification reply shows nothing before reply
2. status in contest shows submissions of contestants
3. fix penalty scoreboard to "submit times / first AC time since contest start(min)"
4. admin can see all clarification
5. hide rejudge, remove contestant button
6. remove contest link color in contest Archive
7. add for all team in clarification column
   ![2015-04-28 10 37 10](https://cloud.githubusercontent.com/assets/9431996/7361841/c4532caa-ed92-11e4-94ec-3b3597f6b8c7.png)
8. add no response button
   ![2015-04-28 10 37 18](https://cloud.githubusercontent.com/assets/9431996/7361842/c7a01094-ed92-11e4-82f4-147062e993d8.png)
9. fix reply description too long
   ![2015-04-28 11 05 57](https://cloud.githubusercontent.com/assets/9431996/7362093/a0eb2a34-ed96-11e4-8311-f5c70c10b394.png)
10. widen multiselect pool
    ![2015-04-28 11 16 03](https://cloud.githubusercontent.com/assets/9431996/7362199/1f9ece3e-ed98-11e4-82f3-1534e0b74869.png)
11. fix "when coowner edit contest, will automatically be removed" bug
12. coowner can not edit coowner list
