### PR TITLE
Fix freeze time

### DIFF
--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -327,6 +327,11 @@ def has_started(contest):
 def is_ended(contest):
     return (datetime.datetime.now() > contest.end_time)
 
+# True if contest is not ended and during freeze time
+def is_freezed(contest):
+    freeze_time = get_freeze_time_datetime(contest)
+    return (datetime.datetime.now() > freeze_time) and not is_ended(contest)
+
 def get_freeze_time_datetime(contest):
     freeze_time = contest.freeze_time
     return contest.end_time - datetime.timedelta(minutes = freeze_time)

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -20,7 +20,6 @@
 import datetime
 import string
 import random
-from datetime import datetime
 from contest.models import Contest
 from contest.models import Contestant
 from contest.models import Clarification

--- a/contest/contest_info.py
+++ b/contest/contest_info.py
@@ -17,13 +17,10 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
     '''
-<<<<<<< HEAD
 import datetime
-=======
 import string
 import random
 from datetime import datetime
->>>>>>> dev
 from contest.models import Contest
 from contest.models import Contestant
 from contest.models import Clarification

--- a/contest/forms.py
+++ b/contest/forms.py
@@ -17,10 +17,12 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
     '''
+import datetime
 from django import forms
 from django.views.generic.edit import UpdateView
 from contest.models import Contest
 from contest.models import Clarification
+from contest.contest_info import get_freeze_time_datetime
 from users.models import User
 from datetimewidget.widgets import DateTimeWidget, DateWidget, TimeWidget
 from problem.models import Problem
@@ -74,6 +76,15 @@ class ContestForm(forms.ModelForm):
             'is_homework',
             'open_register',
         )
+    def clean_freeze_time(self):
+        start_time = self.cleaned_data.get("start_time")
+        freeze_time = self.cleaned_data.get("freeze_time")
+        end_time = self.cleaned_data.get("end_time")
+
+        if type(end_time) is datetime.datetime:
+            if end_time - datetime.timedelta(minutes = freeze_time) <= start_time:
+                raise forms.ValidationError("Freeze time cannot longer than Contest duration.")
+        return freeze_time
 
     def clean_end_time(self):
         start_time = self.cleaned_data.get("start_time")

--- a/contest/static/contest/js/contest.js
+++ b/contest/static/contest/js/contest.js
@@ -20,6 +20,8 @@ SOFTWARE.
 $(document).ready(function() {
     bootstraptify();
     init();
+    $('[data-toggle="tooltip"]').tooltip();
+    $('.progress').css('overflow', 'inherit');
 });
 
 

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -145,7 +145,14 @@
         <div class="tab-pane" id="scoreboard">
           {% include "contest/scoreboard.html" %}
         </div>
-        <div class="tab-pane" id="status">{{ status|safe }}</div>
+        <div class="tab-pane" id="status">
+          {{ status|safe }}
+          <a href="{% url 'status:status' %}?cid={{ contest.id }}">
+            <button type="button" class="btn btn-info btn-block">
+              See More Status
+            </button>
+          </a>
+        </div>
       </div>
     </div>
     {% if user|can_ask:contest %}

--- a/contest/templates/contest/contest.html
+++ b/contest/templates/contest/contest.html
@@ -23,6 +23,11 @@
         </button>
       </a>
       {% endif %}
+      {% if contest|is_freezed %}
+      <h4>
+      <span class="label label-danger">Freezed</span>
+      </h4>
+      {% endif %}
       </h2>
     </div>
     <div class="panel panel-info">

--- a/contest/templates/contest/editContest.html
+++ b/contest/templates/contest/editContest.html
@@ -41,9 +41,11 @@
       {{ field.as_hidden }}
       {% else %}
       {{ field|bootstrap }}
+      {{ field.errors }}
       {% endif %}
     {% else %}
       {{ field|bootstrap }}
+      {{ field.errors }}
     {% endif %}
     {% endfor %}
   <input class="btn btn-primary" type="submit" value="Submit">

--- a/contest/templates/contest/overview.html
+++ b/contest/templates/contest/overview.html
@@ -22,13 +22,13 @@
         No Submission
         {% else %}
         <div class="progress">
-          <div name="pass" class="progress-bar progress-bar-success"
-               style="width: {{ problem.pass_rate }}%;"
+          <div class="progress-bar progress-bar-success" 
+               style="width: {{problem.pass_rate}}%;"
                data-toggle="tooltip" data-placement="top" 
                title="{{problem.pass_rate|floatformat:2}}%">
           </div>
-          <div name="not_pass" class="progress-bar progress-bar-danger"
-               style="width: {{ problem.not_pass_rate }}%;"
+          <div class="progress-bar progress-bar-danger" 
+               style="width: {{problem.not_pass_rate}}%;"
                data-toggle="tooltip" data-placement="top" 
                title="{{problem.not_pass_rate|floatformat:2}}%">
           </div>

--- a/contest/templates/contest/overview.html
+++ b/contest/templates/contest/overview.html
@@ -6,7 +6,7 @@
     <tr>
       <th>#</th>
       <th>Problem</th>
-      <th>Pass Rate</th>
+      <th>Pass Rate (passed user / total user)</th>
     </tr>
   </thead>
   <tbody>

--- a/contest/templatetags/contest_extras.py
+++ b/contest/templatetags/contest_extras.py
@@ -75,6 +75,12 @@ def is_coowner(user, contest):
     return contest_info.is_coowner(user, contest)
 register.filter("is_coowner", is_coowner)
 
+#check if contest is freezed
+@register.filter
+def is_freezed(contest):
+    return contest_info.is_freezed(contest)
+register.filter("is_freezed", is_freezed)
+
 #check if user is judge or admin
 @register.filter
 def has_judge_auth(user):


### PR DESCRIPTION
1. fix freeze time, status and scoreboard won't show data after freeze_time if contest is not ended. If contest is ended, then show all data.
2. add button to redirect to status page to see all submission
   ![2015-04-30 21 37 57](https://cloud.githubusercontent.com/assets/9431996/7413798/4943ba70-ef81-11e4-8c35-9bf0710ce75b.png)
3. add freeze tag
   ![2015-04-30 21 39 07](https://cloud.githubusercontent.com/assets/9431996/7413810/61e17e78-ef81-11e4-9dee-24e2f9d8f027.png)
