### PR TITLE
Cache status result count for faster paging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # User upload files
 media/
 
+# Collected static
+/static
+
 # Configs
 config/
 

--- a/index/templates/index/base.html
+++ b/index/templates/index/base.html
@@ -110,7 +110,7 @@
         <div class="navbar-collapse collapse">
           <p class="navbar-text col-lg-4">Contact us: nthucsoj@gmail.com</p>
           <p class="navbar-text col-lg-6">© NTHU Online Judge 2015, Templates are from Bootswatch Project</p>
-          <p id="time" class="navbar-text">{% now 'Y/m/d f:s' %}</p>
+          <p id="time" class="navbar-text">{% now "Y/m/d H:i:s" %}</p>
         </div>
       </div>
     </footer>

--- a/nthuoj/settings.py
+++ b/nthuoj/settings.py
@@ -80,6 +80,7 @@ DATABASES = {
         'OPTIONS': {
             'read_default_file': CONFIG_PATH,
         },
+        'CONN_MAX_AGE': 120,
     }
 }
 

--- a/nthuoj/settings.py
+++ b/nthuoj/settings.py
@@ -80,7 +80,6 @@ DATABASES = {
         'OPTIONS': {
             'read_default_file': CONFIG_PATH,
         },
-        'CONN_MAX_AGE': 120,
     }
 }
 

--- a/problem/tests.py
+++ b/problem/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/problem/views.py
+++ b/problem/views.py
@@ -66,7 +66,7 @@ def problem(request):
             problem_list = problem_list.filter(tags__tag_name=tag_name)
             for p in problem_list:
                 p.in_contest = check_in_contest(p)
-        problems = get_current_page(request, problem_list, 15)
+        problems = get_current_page(request, problem_list, slice=15)
         for p in problems:
             if p.total_submission != 0:
                 p.pass_rate = float(p.ac_count) / float(p.total_submission) * 100.0

--- a/problem/views.py
+++ b/problem/views.py
@@ -69,8 +69,7 @@ def problem(request):
         problems = get_current_page(request, problem_list, 15)
         for p in problems:
             if p.total_submission != 0:
-                p.pass_rate = float(
-                    p.ac_count) / float(p.total_submission) * 100.0
+                p.pass_rate = float(p.ac_count) / float(p.total_submission) * 100.0
                 p.not_pass_rate = 100.0 - p.pass_rate
                 p.pass_rate = "%.2f" % (p.pass_rate)
                 p.not_pass_rate = "%.2f" % (p.not_pass_rate)

--- a/status/views.py
+++ b/status/views.py
@@ -23,6 +23,7 @@ SOFTWARE.
 """
 import re
 import json
+import time
 import urllib
 
 from django.contrib import messages
@@ -54,6 +55,7 @@ logger = get_logger()
 
 
 def status(request):
+    start_time = time.time()
     status_filter = StatusFilter(request.GET)
     submissions = get_visible_submission(request.user).order_by('-id')
     render_data = {}
@@ -103,7 +105,7 @@ def status(request):
         messages.warning(request, 'No submissions found for the given query!')
 
     render_data['submissions'] = submissions
-
+    render_data['searching_time'] = time.time() - start_time
     return render_index(request, 'status/status.html', render_data)
 
 

--- a/utils/render_helper.py
+++ b/utils/render_helper.py
@@ -71,15 +71,16 @@ def custom_proc(request):
     }
 
 
-def get_current_page(request, objects, slice=25):
+def get_current_page(request, objects, **kwargs):
     """Template for paging
         `objects` is the universe of the set.
 
         Returns a subset of `objects` according to the given page.
     """
-    paginator = Paginator(objects, slice)  # Show 25 items per page by default
+    # Show 25 items per page by default
+    paginator = Paginator(objects, kwargs.get('slice', 25))
     page = request.GET.get('page')
-
+    paginator._count = kwargs.get('count')
     try:
         objects = paginator.page(page)
     except PageNotAnInteger:

--- a/utils/templates/utils/pager.html
+++ b/utils/templates/utils/pager.html
@@ -16,7 +16,7 @@
         name="page" value="{{ objects.number }}">
         of {{ objects.paginator.num_pages }}.
         {% if searching_time %}
-          ({{ searching_time|floatformat:'-2' }} seconds)
+          ({{ searching_time|floatformat:'-3' }} seconds)
         {% endif %}
       </span>
       {% if objects.has_next %}

--- a/utils/templates/utils/pager.html
+++ b/utils/templates/utils/pager.html
@@ -15,6 +15,9 @@
         <input type="text" class="form-control input-sm" style="width: 50px;"
         name="page" value="{{ objects.number }}">
         of {{ objects.paginator.num_pages }}.
+        {% if searching_time %}
+          ({{ searching_time|floatformat:'-2' }} seconds)
+        {% endif %}
       </span>
       {% if objects.has_next %}
         <li>


### PR DESCRIPTION
I noticed that calling `QuerySet.count()` for large table will takes a lot of time. When a status query without any constraints , it would take like 200~300ms to evaluate. Caching this number, the result can be shown in 10~20ms.
![2015-09-16 3 04 51](https://cloud.githubusercontent.com/assets/6128538/9898387/51ab93c0-5c84-11e5-9f27-aa96db95ce74.png)

Can refer to this url for testing: http://140.114.77.123/status/
